### PR TITLE
Add Scala.js 1.0 support, Drop Scala.js 0.6 and Scala 2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,6 @@ matrix:
     # on each platform.
     - env:
       - CI_SCRIPT: '"fastparseJVM/test; fastparseJS/test; fastparseByteJVM/test; fastparseByteJS/test"'
-      scala: 2.10.6
-      jdk: oraclejdk7
-    - env:
-      - CI_SCRIPT: '"fastparseJVM/test; fastparseJS/test; fastparseByteJVM/test; fastparseByteJS/test"'
       scala: 2.11.11
       jdk: oraclejdk8
     - env:
@@ -45,17 +41,9 @@ matrix:
     # a smaller cross-test matrix than for fastparse itself
     - env:
       - CI_SCRIPT: '"classparseJVM/test; classparseJS/test"'
-      scala: 2.10.6
-      jdk: oraclejdk7
-    - env:
-      - CI_SCRIPT: '"classparseJVM/test; classparseJS/test"'
       scala: 2.12.3
       jdk: oraclejdk8
 
-    - env:
-      - CI_SCRIPT: '"scalaparseJVM/test; scalaparseJS/test"'
-      scala: 2.10.6
-      jdk: oraclejdk7
     - env:
       - CI_SCRIPT: '"scalaparseJVM/test; scalaparseJS/test"'
       scala: 2.12.3

--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,7 @@ def macroDependencies(version: String) =
   collection.Seq(
     "org.scala-lang" % "scala-reflect" % version % "provided",
     "org.scala-lang" % "scala-compiler" % version % "provided"
-  ) ++
-  (if (version startsWith "2.10.")
-     collection.Seq(compilerPlugin("org.scalamacros" % s"paradise" % "2.1.0" cross CrossVersion.full),
-         "org.scalamacros" %% s"quasiquotes" % "2.1.0")
-   else
-     collection.Seq())
+  )
 
 val shared = collection.Seq(
   libraryDependencies ++= macroDependencies(scalaVersion.value),

--- a/build.sbt
+++ b/build.sbt
@@ -223,7 +223,9 @@ lazy val demo = project.enablePlugins(ScalaJSPlugin)
     is212Only,
     libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.2",
     libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.6.5",
-    emitSourceMaps := false,
+    scalaJSLinkerConfig ~= {
+      _.withSourceMap(false)
+    },
     noPublish
   )
 

--- a/project/Constants.scala
+++ b/project/Constants.scala
@@ -1,7 +1,6 @@
 package scala.meta.internal.fastparse
 object Constants{
   val version = "1.0.1"
-  val scala210 = "2.10.7"
   val scala211 = "2.11.12"
   val scala212 = "2.12.8"
   val scala213 = "2.13.0-RC1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.3.10

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,21 +1,17 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
 
-addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.9")
+addSbtPlugin("org.openmole" % "scalatex-sbt-plugin" % "0.4.5")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.9")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC10")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.8")
-
-addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")


### PR DESCRIPTION
Scala.js 1.0 requires sbt 1.x and Scala 2.11+.

I assume that dropping Scala 2.10 is fine, since https://github.com/scalameta/scalameta no longer support Scala 2.10.